### PR TITLE
feat: implementa o arquivo .c do código.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ target_include_directories(pwm PRIVATE
 
 # Add any user requested libraries
 target_link_libraries(pwm 
-        
+        hardware_pwm
         )
 
 pico_add_extra_outputs(pwm)

--- a/pwm.c
+++ b/pwm.c
@@ -1,0 +1,65 @@
+#include <stdio.h>
+#include "pico/stdlib.h"
+#include "hardware/pwm.h"
+
+// Defines
+#define PIN_SERVO 22
+#define STEP 5
+
+// Variáveis Globais
+const uint16_t duty_cycles[] = {2400, 1470, 500};
+uint8_t tamanho = 0;
+uint32_t servo_level = 500;
+bool up_down = true;
+
+// Prototipação das funções
+void pwm_setup();
+void set_servo_position(uint16_t dutyCycle);
+void smooth_movement();
+
+int main() {
+    
+    // Inicializações
+    stdio_init_all();
+    pwm_setup();
+    
+    while (true) {
+        while(tamanho < 3){
+            set_servo_position(duty_cycles[tamanho]);
+            tamanho++;
+        }
+        if(tamanho == 3){
+            smooth_movement();
+        }
+    }
+}
+
+void pwm_setup() {
+    gpio_set_function(PIN_SERVO, GPIO_FUNC_PWM);
+    uint sliceNum = pwm_gpio_to_slice_num(PIN_SERVO);
+    pwm_config config = pwm_get_default_config();
+    pwm_config_set_clkdiv(&config, 125.f);
+    pwm_config_set_wrap(&config, 20000);
+    pwm_init(sliceNum, &config, true);
+}
+
+void set_servo_position(uint16_t dutyCycle) {
+    // Seta a posição do servo motor com base no Duty Cycle
+    pwm_set_gpio_level(PIN_SERVO, dutyCycle);
+    sleep_ms(5000);
+}
+
+void smooth_movement() {
+    // Rotina para movimentação periódica do braço do servomotor
+    if (up_down) {
+        servo_level += STEP;
+        if (servo_level >= 2400)
+            up_down = false;
+    } else {
+        servo_level -= STEP;
+        if (servo_level <= 500)
+            up_down = true;
+    }
+    pwm_set_gpio_level(PIN_SERVO, servo_level);
+    sleep_ms(10);
+}


### PR DESCRIPTION
No arquivo `CMakeLists.txt`, foi adicionado a biblioteca necessária para o uso do pwm no microcontrolador.

No arquivo `pwm.c`, macros foram definidos a fim de facilitar a implementação do código. Ademais, variáveis globais foram definidas com o objetivo de modularizar o código sem quaisquer preocupações com restrição quanto passagem e utilização de parâmetros. Quanto a implementação das funções:

**> void pwm_setup():** Rotina responsável pela inicialização do PWM bem como definir sua frequência em 50Hz - período de 20ms.

**> void set_servo_position(uint16_t dutyCycle):** Rotina responsável por setar o servo motor na posição desejada - 180, 90 e 0 graus - na devida ordem.

**> void smooth_movement():** Rotina responsável pela movimentação periódica do braço do servomotor entre os 
ângulos de 0 e 180 graus da forma mais suave possível.

**> int main():** Rotina principal responsável pela chamada das outras funções;